### PR TITLE
Use stable gandi API url

### DIFF
--- a/config-template.txt
+++ b/config-template.txt
@@ -13,4 +13,4 @@ a_name = raspbian
 ttl = 900
 
 # Production API
-api = https://dns.beta.gandi.net/api/v5/
+api = https://dns.api.gandi.net/api/v5/


### PR DESCRIPTION
The gandi api has changed its url for a more stable
one. Although https://dns.beta.gandi.net will continue to 
work for the foreseable future, this commits updates the
url to new official one.