### PR TITLE
Add macOS launchDaemons file and instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,12 @@ You can then run the script as a cron job :
 ```
 */15 * * * * python /home/user/gandi-ddns.py
 ```
+
+macOS
+
+```
+cd gandi-ddns
+ln -s $(pwd) /usr/local/gandi-ddns
+sudo cp gandi.ddns.plist /Library/LaunchDaemons/
+sudo launchctl /Library/LaunchDaemons/gandi.ddns.plist
+```

--- a/gandi.ddns.plist
+++ b/gandi.ddns.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>gandi.ddns</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/python3</string>
+    <string>gandi-ddns.py</string>
+  </array>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StartInterval</key>
+  <integer>300</integer> <!-- every 5 mins -->
+
+  <key>KeepAlive</key>
+  <false/>
+
+  <key>WorkingDirectory</key>
+  <string>/usr/local/gandi-ddns/</string>
+
+  <key>StandardErrorPath</key>
+  <string>/usr/local/var/log/gandi-ddns/output.log</string>
+  <key>StandardOutPath</key>
+  <string>/usr/local/var/log/gandi-ddns/output.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
This PR adds a `.plist` file and a few line of instructions in the README for macOS users. 
It's better to use LaunchDaemons and LaunchAgents than cron on mac.