### PR TITLE
Fix sections loop and log datetime + session name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ The config-template.txt file should be renamed to config.txt, and modified with 
 Every time the script runs, it will query an external service to retrieve the external IP of the machine, compare it to the current A record in the zone at gandi.net, and then update the record if the IP has changed.
 
 Requirements:
-  - Python 2.7
   - ipaddress module (pip install ipaddress)
   - requests module (pip install requests)
   - json module (pip install json)

--- a/gandi-ddns.py
+++ b/gandi-ddns.py
@@ -1,4 +1,4 @@
-import ConfigParser as configparser
+import configparser as configparser
 import sys
 import os
 import requests
@@ -17,13 +17,13 @@ def get_ip():
         except Exception:
           print('Failed to retrieve external IP.')
           sys.exit(2)
-	if r.status_code != 200:
-          print('Failed to retrieve external IP. Server responded with status_code: %d' % r.status_code)
+        if r.status_code != 200:
+          print(('Failed to retrieve external IP. Server responded with status_code: %d' % r.status_code))
           sys.exit(2)
 
         ip = r.text.rstrip() # strip \n and any trailing whitespace
 
-	if not(ipaddress.IPv4Address(ip)): # check if valid IPv4 address
+        if not(ipaddress.IPv4Address(ip)): # check if valid IPv4 address
           sys.exit(2)
 
         return ip
@@ -45,8 +45,8 @@ def update_record(url, headers, payload):
         #Add record
         r = requests.put(url, headers=headers, json=payload)
         if r.status_code != 201:
-          print('Record update failed with status code: %d' % r.status_code)
-          print(r.text)
+          print(('Record update failed with status code: %d' % r.status_code))
+          print((r.text))
           sys.exit(2)
         print ('Zone record updated.')
 
@@ -62,7 +62,7 @@ def main():
     sys.exit("Please fill in the 'config.txt' file.")
 
   for section in config.sections():
-  
+
     #Retrieve API key
     apikey = config.get(section, 'apikey')
 
@@ -74,7 +74,7 @@ def main():
     print(url)
     #Discover External IP
     external_ip = get_ip()
-    print('External IP is: %s' % external_ip)
+    print(('External IP is: %s' % external_ip))
 
     #Prepare record
     payload = {'rrset_ttl': config.get(section, 'ttl'), 'rrset_values': [external_ip]}
@@ -83,10 +83,10 @@ def main():
     record = get_record(url, headers)
 
     if record.status_code == 200:
-      print('Current record value is: %s' % json.loads(record.text)['rrset_values'][0])
+      print(('Current record value is: %s' % json.loads(record.text)['rrset_values'][0]))
       if(json.loads(record.text)['rrset_values'][0] == external_ip):
         print('No change in IP address. Goodbye.')
-        sys.exit()
+        continue
     else:
       print('No existing record. Adding...')
 

--- a/gandi-ddns.py
+++ b/gandi-ddns.py
@@ -4,6 +4,7 @@ import os
 import requests
 import json
 import ipaddress
+from datetime import datetime
 
 config_file = "config.txt"
 
@@ -62,6 +63,7 @@ def main():
     sys.exit("Please fill in the 'config.txt' file.")
 
   for section in config.sections():
+    print('%s - section %s' % (str(datetime.now()), section))
 
     #Retrieve API key
     apikey = config.get(section, 'apikey')


### PR DESCRIPTION
This PR fixes sections loop (`continue` instead of `sys.exit()`) and add a `print` to show datetime and session name.