### PR TITLE
add retries to get_ip()

### DIFF
--- a/config-template.txt
+++ b/config-template.txt
@@ -14,3 +14,7 @@ ttl = 900
 
 # Production API
 api = https://dns.api.gandi.net/api/v5/
+
+# Number of retries for looking up our own IP address, since
+# the service seems to be flaky sometimes.
+retries = 3


### PR DESCRIPTION
Instead of failing immediately if getting local IP address fails, we try
up to configured number of times, increasing the delay every time.