### PR TITLE
parse "retries" from config as int

### DIFF
--- a/gandi_ddns.py
+++ b/gandi_ddns.py
@@ -100,7 +100,7 @@ def main():
     url = '%sdomains/%s/records/%s/A' % (config.get(section, 'api'), config.get(section, 'domain'), config.get(section, 'a_name'))
     print(url)
     #Discover External IP
-    retries = config.get(section, 'retries', fallback=DEFAULT_RETRIES)
+    retries = int(config.get(section, 'retries', fallback=DEFAULT_RETRIES))
     external_ip = get_ip(retries)
     print(('External IP is: %s' % external_ip))
 


### PR DESCRIPTION
Turns out `config.get` will always give you strings, so if `retries` override was specified, it would get parsed as a string, and fall over later in `get_ip`. This fixes it to parse it as an int.