### PR TITLE
Add Dockerfile, docs, and GitHub CI.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git branch or tag to build
+        required: true
+
+jobs:
+  docker:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - gandi_ddns: 1.0.0
+            alpine: 3.13.0
+            tags: 1.0.0-alpine3.13.0,1.0.0,1.0,1
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ilteoood/docker_buildx@1.1.0
+        with:
+          tag: ${{ matrix.tags }}
+          imageName: cjyar/gandi-ddns
+          buildArg: ALPINE_VERSION=${{ matrix.alpine }},GANDI_DDNS_VERSION=${{ matrix.gandi_ddns }}
+          publish: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'workflow_dispatch' }}
+          dockerUser: cjyar
+          dockerPassword: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,8 +25,8 @@ jobs:
       - uses: ilteoood/docker_buildx@1.1.0
         with:
           tag: ${{ matrix.tags }}
-          imageName: cjyar/gandi-ddns
+          imageName: rmarchent/gandi-ddns
           buildArg: ALPINE_VERSION=${{ matrix.alpine }},GANDI_DDNS_VERSION=${{ matrix.gandi_ddns }}
           publish: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'workflow_dispatch' }}
-          dockerUser: cjyar
+          dockerUser: rmarchent
           dockerPassword: ${{ secrets.DOCKER_PASSWORD }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:3.13 as base
+
+RUN apk add \
+    python3 \
+    py3-pip
+WORKDIR /gandi-ddns
+ADD requirements.txt gandi_ddns.py ./
+RUN pip install -r requirements.txt
+
+FROM base as test
+
+RUN apk add py3-pytest
+ADD test_gandi_ddns.py ./
+RUN pytest
+
+FROM base as target
+
+CMD [ "./gandi_ddns.py" ]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ But to be nice to the API servers, you should choose a random offset for your jo
 2-59/15 * * * * python /home/user/gandi-ddns.py
 ```
 
-macOS
+# macOS
 
 ```
 cd gandi-ddns
@@ -32,3 +32,15 @@ ln -s $(pwd) /usr/local/gandi-ddns
 sudo cp gandi.ddns.plist /Library/LaunchDaemons/
 sudo launchctl /Library/LaunchDaemons/gandi.ddns.plist
 ```
+
+# Docker
+
+The docker container is published as [`rmarchant/gandi-ddns`](https://hub.docker.com/r/rmarchant/gandi-ddns). To run,
+pass it an argument pointing to the config file. The config file must be mounted into the container's filesystem.
+
+```
+docker run -it --rm -v /path/to/config/file.txt:/config.txt rmarchant/gandi-ddns /config.txt
+```
+
+If you're on Kubernetes, you can create a
+[CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) to run this periodically.

--- a/gandi_ddns.py
+++ b/gandi_ddns.py
@@ -85,6 +85,8 @@ def update_record(url, headers, payload):
 
 def main():
     path = config_file
+    if len(sys.argv) > 1:
+        path = sys.argv[1]
     if not path.startswith('/'):
         path = os.path.join(SCRIPT_DIR, path)
     config = read_config(path)


### PR DESCRIPTION
This PR adds a Docker container. If you want to push the Docker container to `rmarchant/gandi-ddns`, you'll need to:

1. Create an account on hub.docker.com.
2. Generate an access token under Docker Hub's `Account settings` -> `Security`.
3. Create a `gandi-ddns` repo on Docker Hub.
4. Add the token to GitHub's repo -> `Settings` -> `Secrets` as DOCKER_PASSWORD`.

The Docker container is built to be multi-architecture, so it can run on rpi or other platforms. I included a hint about running it in Kubernetes; I can give a lot more detail if you want.

Not sure what to do about CI. I included configuration for GitHub CI to test and build the docker container. But I see you already config for Travis. I know there's a way to do the same thing in Travis, but I haven't been on that platform in a while.