### PR TITLE
Use official Gandi Public API URL, remove beta URL

### DIFF
--- a/config-template.txt
+++ b/config-template.txt
@@ -13,7 +13,7 @@ a_name = raspbian
 ttl = 900
 
 # Production API
-gandi_api = https://dns.api.gandi.net/api/v5/
+gandi_api = https://api.gandi.net/v5/livedns/
 
 # Number of retries for looking up our own IP address, since
 # the service seems to be flaky sometimes.

--- a/gandi_ddns.py
+++ b/gandi_ddns.py
@@ -98,7 +98,7 @@ def main():
         apikey = config.get(section, 'apikey')
 
         # Set headers
-        headers = {'Content-Type': 'application/json', 'X-Api-Key': '%s' % apikey}
+        headers = {'Content-Type': 'application/json', 'Authorization': 'Apikey %s' % apikey}
 
         # Set URL
         url = '%sdomains/%s/records/%s/A' % (config.get(section, 'gandi_api'),


### PR DESCRIPTION
Moving from : https://doc.livedns.gandi.net/

To : https://api.gandi.net/docs/livedns/